### PR TITLE
EDD License requests: set ssl_verify true

### DIFF
--- a/src/core/License.php
+++ b/src/core/License.php
@@ -134,7 +134,7 @@ class License
             $url,
             [
                 'timeout'   => 30,
-                'sslverify' => false,
+                'sslverify' => true,
                 'body'      => $body
             ]
         );


### PR DESCRIPTION
If wp_remote_post() is called with ssl_verify set false, requests to publishpress.com failed with Open SSL message "handshake failure" and "unable to connect to ssl://publishpress.com/443